### PR TITLE
Return empty array if no list items exist

### DIFF
--- a/server/models/listItemModel.js
+++ b/server/models/listItemModel.js
@@ -30,7 +30,8 @@ module.exports = {
             });
         });
       } else {
-        res.end();
+        // return an empty array if there are no listItems
+        res.json([]);
       }
     });
   },


### PR DESCRIPTION
Self-explanatory: we were previously returning an empty string, need to return an empty array.
